### PR TITLE
Updated max epoch number to return as type int

### DIFF
--- a/code/cifar10-training-sagemaker.py
+++ b/code/cifar10-training-sagemaker.py
@@ -80,7 +80,7 @@ def load_checkpoint_model(checkpoint_path):
     print('------------------------------------')
     
     resume_model = load_model(f'{checkpoint_path}/{max_epoch_filename}')
-    return resume_model, max_epoch_number
+    return resume_model, int(max_epoch_number)
 
 
 def get_model(model_type, input_shape, learning_rate, weight_decay, optimizer, momentum):


### PR DESCRIPTION
When loading from a checkpoint with function `load_checkpoint_model()`, the epoch number from the latest run is returned as string.  This leads to an error when calling `.fit()` on line 159 when Keras enters a for loop and assumes the parameter `initial_epoch` inside of a `range()` call.